### PR TITLE
Add templateservicebrokers/status to rbac

### DIFF
--- a/files/tsb/01-tsb-catalogsource-configmap.yaml
+++ b/files/tsb/01-tsb-catalogsource-configmap.yaml
@@ -120,6 +120,7 @@ data:
                 - osb.openshift.io
                 resources:
                 - templateservicebrokers
+                - templateservicebrokers/status
                 verbs:
                 - "*"
               - apiGroups:


### PR DESCRIPTION
Fix for TSB operator error with latest ansible-operator base image that uses  `status` subresource. Not an issue on ASB operator since ASB operator has broader cluster permissions on the `automationbroker` resource type. (https://github.com/fusor/catbrokers4/blob/master/files/asb/01-asb-catalogsource-configmap.yaml#L180-L185)

```
"error":"templateservicebrokers.osb.openshift.io \"template-service-broker\" is forbidden: User \"system:serviceaccount:openshift-template-service-broker:template-service-broker-operator\" cannot update templateservicebrokers.osb.openshift.io/status in the namespace \"openshift-template-service-broker\": no RBAC policy matched"
```