### PR TITLE
Bug 1664506 - Update operator resource names to maintain 3.11 backwards compatibility

### DIFF
--- a/files/asb/00-asb-namespace.yaml
+++ b/files/asb/00-asb-namespace.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: automation-broker
+  name: openshift-ansible-service-broker

--- a/files/asb/01-asb-catalogsource-configmap.yaml
+++ b/files/asb/01-asb-catalogsource-configmap.yaml
@@ -64,7 +64,7 @@ data:
         name: automationbrokeroperator.v0.1.0
         namespace: placeholder
         annotations:
-          alm-examples: '[{"apiVersion":"automationbroker.io/v1alpha1","kind":"AutomationBroker","metadata":{"name":"automation-broker","namespace":"automation-broker"},"spec":{"createBrokerNamespace":"false","waitForBroker":"false"}}]'
+          alm-examples: '[{"apiVersion":"automationbroker.io/v1alpha1","kind":"AutomationBroker","metadata":{"name":"ansible-service-broker","namespace":"openshift-ansible-service-broker"},"spec":{"createBrokerNamespace":"false","waitForBroker":"false"}}]'
       spec:
         displayName: Automation Broker Operator
         description: |

--- a/files/asb/01-asb-catalogsource-configmap.yaml
+++ b/files/asb/01-asb-catalogsource-configmap.yaml
@@ -148,7 +148,7 @@ data:
                 - deploymentconfigs
                 verbs:
                 - "*"
-            - serviceAccountName: automation-broker
+            - serviceAccountName: ansible-service-broker
               rules:
               - apiGroups:
                 - ""
@@ -231,7 +231,7 @@ data:
               #  - get
               #  - patch
               #  - update
-            - serviceAccountName: automation-broker
+            - serviceAccountName: ansible-service-broker
               rules:
               - apiGroups:
                 - ""
@@ -313,7 +313,7 @@ data:
                 - netnamespaces
                 verbs:
                 - update
-            - serviceAccountName: automation-broker-client
+            - serviceAccountName: ansible-service-broker-client
               rules:
               - nonResourceURLs:
                 - "/osb"

--- a/files/asb/02-asb-catalogsource.yaml
+++ b/files/asb/02-asb-catalogsource.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
 spec:
   configMap: asb-operator
-  displayName: Automation Broker
+  displayName: Ansible Service Broker
   publisher: Red Hat
   sourceType: internal

--- a/files/asb/03-asb-operatorgroup.yaml
+++ b/files/asb/03-asb-operatorgroup.yaml
@@ -1,9 +1,9 @@
 apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup
 metadata:
-  name: automation-broker
-  namespace: automation-broker
+  name: ansible-service-broker
+  namespace: openshift-ansible-service-broker
 spec:
   selector:
     matchLabels:
-      ns: automation-broker
+      ns: openshift-ansible-service-broker

--- a/files/asb/04-asb-subscription.yaml
+++ b/files/asb/04-asb-subscription.yaml
@@ -1,8 +1,8 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  generateName: automationbroker-
-  namespace: automation-broker
+  generateName: ansible-service-broker-
+  namespace: openshift-ansible-service-broker
 spec:
   source: asb-operator
   name: automationbroker

--- a/files/asb/05-asb-cr.yaml
+++ b/files/asb/05-asb-cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: automationbroker.io/v1alpha1
 kind: AutomationBroker
 metadata:
-  name: automation-broker
-  namespace: automation-broker
+  name: ansible-service-broker
+  namespace: openshift-ansible-service-broker
 spec:
   createBrokerNamespace: 'false'

--- a/files/asb/06-asb-clusterrolebinding.yaml
+++ b/files/asb/06-asb-clusterrolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: automation-broker-admin
+  name: ansible-service-broker-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: admin
 subjects:
 - kind: ServiceAccount
-  name: automation-broker
-  namespace: automation-broker
+  name: ansible-service-broker
+  namespace: openshift-ansible-service-broker


### PR DESCRIPTION
Current values are blocking QE testing, need to use previous 3.11 resource names:

https://bugzilla.redhat.com/show_bug.cgi?id=1664506